### PR TITLE
Add popular activities for destinations

### DIFF
--- a/backend/handlers/activity_handler.go
+++ b/backend/handlers/activity_handler.go
@@ -1,0 +1,192 @@
+package handlers
+
+import (
+	"database/sql"
+	"net/http"
+	"strconv"
+	"time"
+
+	"backend/database"
+	"backend/models"
+
+	"github.com/gin-gonic/gin"
+)
+
+// GetActivities returns all activities for a destination
+func GetActivities(c *gin.Context) {
+	destID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{Error: "bad_request", Message: "Invalid destination ID"})
+		return
+	}
+
+	// Check destination exists
+	var destExists int
+	err = database.DB.QueryRow("SELECT COUNT(*) FROM destinations WHERE id = ?", destID).Scan(&destExists)
+	if err != nil || destExists == 0 {
+		c.JSON(http.StatusNotFound, models.ErrorResponse{Error: "not_found", Message: "Destination not found"})
+		return
+	}
+
+	rows, err := database.DB.Query(`
+		SELECT id, destination_id, name, description, category, created_at, updated_at
+		FROM activities
+		WHERE destination_id = ?
+		ORDER BY name ASC
+	`, destID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, models.ErrorResponse{Error: "server_error", Message: "Failed to fetch activities"})
+		return
+	}
+	defer rows.Close()
+
+	activities := []models.ActivityResponse{}
+	for rows.Next() {
+		var a models.ActivityResponse
+		var description, category sql.NullString
+		err := rows.Scan(&a.ID, &a.DestinationID, &a.Name, &description, &category, &a.CreatedAt, &a.UpdatedAt)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, models.ErrorResponse{Error: "server_error", Message: "Error reading activities"})
+			return
+		}
+		if description.Valid {
+			a.Description = description.String
+		}
+		if category.Valid {
+			a.Category = category.String
+		}
+		activities = append(activities, a)
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"destination_id":   destID,
+		"total_activities": len(activities),
+		"activities":       activities,
+	})
+}
+
+// CreateActivity adds a new activity for a destination
+func CreateActivity(c *gin.Context) {
+	_, exists := c.Get("user")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, models.ErrorResponse{Error: "unauthorized", Message: "User not authenticated"})
+		return
+	}
+
+	destID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{Error: "bad_request", Message: "Invalid destination ID"})
+		return
+	}
+
+	var req models.CreateActivityRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{Error: "bad_request", Message: "Invalid request payload"})
+		return
+	}
+
+	if req.Name == "" {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{Error: "validation_error", Message: "Activity name is required"})
+		return
+	}
+
+	// Check destination exists
+	var destExists int
+	err = database.DB.QueryRow("SELECT COUNT(*) FROM destinations WHERE id = ?", destID).Scan(&destExists)
+	if err != nil || destExists == 0 {
+		c.JSON(http.StatusNotFound, models.ErrorResponse{Error: "not_found", Message: "Destination not found"})
+		return
+	}
+
+	now := time.Now()
+	result, err := database.DB.Exec(
+		"INSERT INTO activities (destination_id, name, description, category, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+		destID, req.Name, req.Description, req.Category, now, now,
+	)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, models.ErrorResponse{Error: "server_error", Message: "Failed to create activity"})
+		return
+	}
+
+	activityID, _ := result.LastInsertId()
+	c.JSON(http.StatusCreated, gin.H{
+		"message":     "Activity created successfully",
+		"activity_id": activityID,
+	})
+}
+
+// UpdateActivity updates an existing activity
+func UpdateActivity(c *gin.Context) {
+	_, exists := c.Get("user")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, models.ErrorResponse{Error: "unauthorized", Message: "User not authenticated"})
+		return
+	}
+
+	activityID, err := strconv.Atoi(c.Param("activityId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{Error: "bad_request", Message: "Invalid activity ID"})
+		return
+	}
+
+	var req models.UpdateActivityRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{Error: "bad_request", Message: "Invalid request payload"})
+		return
+	}
+
+	if req.Name == "" {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{Error: "validation_error", Message: "Activity name is required"})
+		return
+	}
+
+	// Check activity exists
+	var existingID int
+	err = database.DB.QueryRow("SELECT id FROM activities WHERE id = ?", activityID).Scan(&existingID)
+	if err == sql.ErrNoRows {
+		c.JSON(http.StatusNotFound, models.ErrorResponse{Error: "not_found", Message: "Activity not found"})
+		return
+	}
+
+	_, err = database.DB.Exec(
+		"UPDATE activities SET name = ?, description = ?, category = ?, updated_at = ? WHERE id = ?",
+		req.Name, req.Description, req.Category, time.Now(), activityID,
+	)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, models.ErrorResponse{Error: "server_error", Message: "Failed to update activity"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Activity updated successfully"})
+}
+
+// DeleteActivity deletes an activity by ID
+func DeleteActivity(c *gin.Context) {
+	_, exists := c.Get("user")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, models.ErrorResponse{Error: "unauthorized", Message: "User not authenticated"})
+		return
+	}
+
+	activityID, err := strconv.Atoi(c.Param("activityId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{Error: "bad_request", Message: "Invalid activity ID"})
+		return
+	}
+
+	// Check activity exists
+	var existingID int
+	err = database.DB.QueryRow("SELECT id FROM activities WHERE id = ?", activityID).Scan(&existingID)
+	if err == sql.ErrNoRows {
+		c.JSON(http.StatusNotFound, models.ErrorResponse{Error: "not_found", Message: "Activity not found"})
+		return
+	}
+
+	_, err = database.DB.Exec("DELETE FROM activities WHERE id = ?", activityID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, models.ErrorResponse{Error: "server_error", Message: "Failed to delete activity"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Activity deleted successfully"})
+}

--- a/backend/handlers/activity_test.go
+++ b/backend/handlers/activity_test.go
@@ -1,0 +1,203 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"backend/database"
+	"backend/utils"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupActivityRouter() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+
+	r.Use(func(c *gin.Context) {
+		c.Set("user", &utils.Claims{UserID: 1})
+		c.Next()
+	})
+
+	r.GET("/api/destinations/:id/activities", GetActivities)
+	r.POST("/api/destinations/:id/activities", CreateActivity)
+	r.PUT("/api/destinations/:id/activities/:activityId", UpdateActivity)
+	r.DELETE("/api/destinations/:id/activities/:activityId", DeleteActivity)
+
+	return r
+}
+
+func setupActivityDB(t *testing.T) {
+	err := database.InitDB(":memory:")
+	if err != nil {
+		t.Fatalf("Failed to init test DB: %v", err)
+	}
+
+	_, err = database.DB.Exec(`
+		CREATE TABLE IF NOT EXISTS destinations (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT, country TEXT, budget REAL, description TEXT
+		);
+		CREATE TABLE IF NOT EXISTS activities (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			destination_id INTEGER NOT NULL,
+			name TEXT NOT NULL,
+			description TEXT,
+			category TEXT,
+			created_at DATETIME,
+			updated_at DATETIME,
+			FOREIGN KEY (destination_id) REFERENCES destinations(id)
+		);
+	`)
+	if err != nil {
+		t.Fatalf("Failed to create tables: %v", err)
+	}
+
+	// Seed a destination
+	database.DB.Exec(`INSERT INTO destinations (id, name, country, budget, description) VALUES (1, 'Paris', 'France', 2000, 'City of Light')`)
+}
+
+func TestActivityFlow(t *testing.T) {
+	setupActivityDB(t)
+	defer database.CloseDB()
+
+	router := setupActivityRouter()
+
+	// -------------------------
+	// 1. Get Activities - Empty List
+	// -------------------------
+	req, _ := http.NewRequest("GET", "/api/destinations/1/activities", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var getRes map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &getRes)
+	assert.Equal(t, float64(0), getRes["total_activities"])
+
+	// -------------------------
+	// 2. Get Activities - Non-existent Destination
+	// -------------------------
+	req, _ = http.NewRequest("GET", "/api/destinations/999/activities", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	// -------------------------
+	// 3. Create Activity - Success
+	// -------------------------
+	body := `{"name": "Eiffel Tower Visit", "description": "Visit the iconic tower", "category": "Sightseeing"}`
+	req, _ = http.NewRequest("POST", "/api/destinations/1/activities", bytes.NewBuffer([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	var createRes map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &createRes)
+	activityID := int(createRes["activity_id"].(float64))
+
+	// -------------------------
+	// 4. Create Activity - Missing Name
+	// -------------------------
+	noName := `{"name": "", "description": "No name activity"}`
+	req, _ = http.NewRequest("POST", "/api/destinations/1/activities", bytes.NewBuffer([]byte(noName)))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	// -------------------------
+	// 5. Create Activity - Non-existent Destination
+	// -------------------------
+	req, _ = http.NewRequest("POST", "/api/destinations/999/activities", bytes.NewBuffer([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	// -------------------------
+	// 6. Get Activities - Now has 1
+	// -------------------------
+	req, _ = http.NewRequest("GET", "/api/destinations/1/activities", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	json.Unmarshal(w.Body.Bytes(), &getRes)
+	assert.Equal(t, float64(1), getRes["total_activities"])
+
+	activities := getRes["activities"].([]interface{})
+	first := activities[0].(map[string]interface{})
+	assert.Equal(t, "Eiffel Tower Visit", first["name"])
+	assert.Equal(t, "Sightseeing", first["category"])
+
+	// -------------------------
+	// 7. Update Activity - Success
+	// -------------------------
+	updateBody := `{"name": "Eiffel Tower Night Visit", "description": "Visit at night", "category": "Sightseeing"}`
+	req, _ = http.NewRequest("PUT", fmt.Sprintf("/api/destinations/1/activities/%d", activityID), bytes.NewBuffer([]byte(updateBody)))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// -------------------------
+	// 8. Update Activity - Missing Name
+	// -------------------------
+	badUpdate := `{"name": "", "description": "No name"}`
+	req, _ = http.NewRequest("PUT", fmt.Sprintf("/api/destinations/1/activities/%d", activityID), bytes.NewBuffer([]byte(badUpdate)))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	// -------------------------
+	// 9. Update Activity - Non-existent
+	// -------------------------
+	req, _ = http.NewRequest("PUT", "/api/destinations/1/activities/999", bytes.NewBuffer([]byte(updateBody)))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	// -------------------------
+	// 10. Verify Update - Name changed
+	// -------------------------
+	req, _ = http.NewRequest("GET", "/api/destinations/1/activities", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	json.Unmarshal(w.Body.Bytes(), &getRes)
+	updated := getRes["activities"].([]interface{})[0].(map[string]interface{})
+	assert.Equal(t, "Eiffel Tower Night Visit", updated["name"])
+
+	// -------------------------
+	// 11. Delete Activity - Non-existent
+	// -------------------------
+	req, _ = http.NewRequest("DELETE", "/api/destinations/1/activities/999", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	// -------------------------
+	// 12. Delete Activity - Success
+	// -------------------------
+	req, _ = http.NewRequest("DELETE", fmt.Sprintf("/api/destinations/1/activities/%d", activityID), nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// -------------------------
+	// 13. Verify Deletion - Empty list again
+	// -------------------------
+	req, _ = http.NewRequest("GET", "/api/destinations/1/activities", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	json.Unmarshal(w.Body.Bytes(), &getRes)
+	assert.Equal(t, float64(0), getRes["total_activities"])
+}

--- a/backend/models/activity.go
+++ b/backend/models/activity.go
@@ -1,0 +1,41 @@
+package models
+
+import "time"
+
+type Activity struct {
+	ID            int       `json:"id"`
+	DestinationID int       `json:"destination_id"`
+	Name          string    `json:"name"`
+	Description   string    `json:"description,omitempty"`
+	Category      string    `json:"category,omitempty"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+type ActivityResponse struct {
+	ID            int       `json:"id"`
+	DestinationID int       `json:"destination_id"`
+	Name          string    `json:"name"`
+	Description   string    `json:"description,omitempty"`
+	Category      string    `json:"category,omitempty"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+type CreateActivityRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Category    string `json:"category,omitempty"`
+}
+
+type UpdateActivityRequest struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	Category    string `json:"category,omitempty"`
+}
+
+type ActivitiesListResponse struct {
+	DestinationID   int                `json:"destination_id"`
+	TotalActivities int                `json:"total_activities"`
+	Activities      []ActivityResponse `json:"activities"`
+}

--- a/backend/router.go
+++ b/backend/router.go
@@ -91,6 +91,12 @@ func main() {
 		api.PUT("/destinations/:id/reviews/:reviewId", handlers.UpdateReview)
 		api.DELETE("/destinations/:id/reviews/:reviewId", handlers.DeleteReview)
 
+		// Activity routes
+		api.GET("/destinations/:id/activities", handlers.GetActivities)
+		api.POST("/destinations/:id/activities", handlers.CreateActivity)
+		api.PUT("/destinations/:id/activities/:activityId", handlers.UpdateActivity)
+		api.DELETE("/destinations/:id/activities/:activityId", handlers.DeleteActivity)
+
 		// Itinerary routes
 		api.POST("/itineraries", handlers.CreateItinerary)
 		api.GET("/itineraries/:id", handlers.GetItinerary)


### PR DESCRIPTION
Added activities management for destinations.

Changes:
- activity_handler.go: CRUD endpoints for destination activities
- activity_test.go: 13 unit tests covering all endpoints
- models/activity.go: Activity model and request/response types
- main.go: Activity routes added to protected API group

Endpoints added:
- GET    /api/destinations/:id/activities
- POST   /api/destinations/:id/activities
- PUT    /api/destinations/:id/activities/:activityId
- DELETE /api/destinations/:id/activities/:activityId