### PR TITLE
Added compare destinations feature endpoint with unit tests

### DIFF
--- a/backend/handlers/compare_handler.go
+++ b/backend/handlers/compare_handler.go
@@ -1,0 +1,94 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"backend/database"
+	"backend/models"
+
+	"github.com/gin-gonic/gin"
+)
+
+// CompareDestinations compares 2-3 destinations side by side
+func CompareDestinations(c *gin.Context) {
+
+	// Get ids query param e.g. ?ids=1,2,3
+	idsParam := c.Query("ids")
+	if idsParam == "" {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "validation_error",
+			Message: "ids query parameter is required e.g. ?ids=1,2,3",
+		})
+		return
+	}
+
+	// Split and parse the IDs
+	idStrings := strings.Split(idsParam, ",")
+
+	if len(idStrings) < 2 {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "validation_error",
+			Message: "At least 2 destination IDs are required for comparison",
+		})
+		return
+	}
+
+	if len(idStrings) > 3 {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "validation_error",
+			Message: "You can compare a maximum of 3 destinations at a time",
+		})
+		return
+	}
+
+	// Validate all IDs are valid integers and no duplicates
+	seen := make(map[int]bool)
+	var ids []int
+	for _, idStr := range idStrings {
+		idStr = strings.TrimSpace(idStr)
+		id, err := strconv.Atoi(idStr)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, models.ErrorResponse{
+				Error:   "validation_error",
+				Message: "All IDs must be valid integers",
+			})
+			return
+		}
+		if seen[id] {
+			c.JSON(http.StatusBadRequest, models.ErrorResponse{
+				Error:   "validation_error",
+				Message: "Duplicate destination IDs are not allowed",
+			})
+			return
+		}
+		seen[id] = true
+		ids = append(ids, id)
+	}
+
+	// Fetch each destination
+	destinations := []models.DestinationComparison{}
+	for _, id := range ids {
+		var dest models.DestinationComparison
+		err := database.DB.QueryRow(
+			"SELECT id, name, country, budget, description FROM destinations WHERE id = ?",
+			id,
+		).Scan(&dest.ID, &dest.Name, &dest.Country, &dest.Budget, &dest.Description)
+
+		if err != nil {
+			c.JSON(http.StatusNotFound, models.ErrorResponse{
+				Error:   "not_found",
+				Message: "Destination with ID " + strconv.Itoa(id) + " not found",
+			})
+			return
+		}
+
+		destinations = append(destinations, dest)
+	}
+
+	c.JSON(http.StatusOK, models.CompareResponse{
+		TotalDestinations: len(destinations),
+		Destinations:      destinations,
+	})
+}

--- a/backend/handlers/compare_test.go
+++ b/backend/handlers/compare_test.go
@@ -1,0 +1,151 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"backend/database"
+	"backend/utils"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupCompareRouter() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+
+	r.Use(func(c *gin.Context) {
+		c.Set("user", &utils.Claims{UserID: 1})
+		c.Next()
+	})
+
+	r.GET("/api/destinations/compare", CompareDestinations)
+
+	return r
+}
+
+func setupCompareDB(t *testing.T) {
+	err := database.InitDB(":memory:")
+	if err != nil {
+		t.Fatalf("Failed to init test DB: %v", err)
+	}
+
+	_, err = database.DB.Exec(`
+		CREATE TABLE IF NOT EXISTS destinations (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT, country TEXT, budget REAL, description TEXT
+		);
+	`)
+	if err != nil {
+		t.Fatalf("Failed to create tables: %v", err)
+	}
+
+	// Seed 3 destinations
+	database.DB.Exec(`INSERT INTO destinations (id, name, country, budget, description) VALUES (1, 'Paris', 'France', 2000, 'City of Light')`)
+	database.DB.Exec(`INSERT INTO destinations (id, name, country, budget, description) VALUES (2, 'Tokyo', 'Japan', 3000, 'Land of the Rising Sun')`)
+	database.DB.Exec(`INSERT INTO destinations (id, name, country, budget, description) VALUES (3, 'Bali', 'Indonesia', 1500, 'Island of the Gods')`)
+}
+
+func TestCompareDestinations(t *testing.T) {
+	setupCompareDB(t)
+	defer database.CloseDB()
+
+	router := setupCompareRouter()
+
+	// -------------------------
+	// 1. Compare 2 Destinations - Success
+	// -------------------------
+	req, _ := http.NewRequest("GET", "/api/destinations/compare?ids=1,2", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var res map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &res)
+	assert.Equal(t, float64(2), res["total_destinations"])
+
+	destinations := res["destinations"].([]interface{})
+	first := destinations[0].(map[string]interface{})
+	second := destinations[1].(map[string]interface{})
+	assert.Equal(t, "Paris", first["name"])
+	assert.Equal(t, "Tokyo", second["name"])
+
+	// -------------------------
+	// 2. Compare 3 Destinations - Success
+	// -------------------------
+	req, _ = http.NewRequest("GET", "/api/destinations/compare?ids=1,2,3", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	json.Unmarshal(w.Body.Bytes(), &res)
+	assert.Equal(t, float64(3), res["total_destinations"])
+
+	// -------------------------
+	// 3. Missing ids param
+	// -------------------------
+	req, _ = http.NewRequest("GET", "/api/destinations/compare", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	// -------------------------
+	// 4. Only 1 ID provided (minimum is 2)
+	// -------------------------
+	req, _ = http.NewRequest("GET", "/api/destinations/compare?ids=1", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	// -------------------------
+	// 5. More than 3 IDs (maximum is 3)
+	// -------------------------
+	req, _ = http.NewRequest("GET", "/api/destinations/compare?ids=1,2,3,4", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	// -------------------------
+	// 6. Invalid ID format (not a number)
+	// -------------------------
+	req, _ = http.NewRequest("GET", "/api/destinations/compare?ids=1,abc", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	// -------------------------
+	// 7. Duplicate IDs
+	// -------------------------
+	req, _ = http.NewRequest("GET", "/api/destinations/compare?ids=1,1", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	// -------------------------
+	// 8. One ID does not exist
+	// -------------------------
+	req, _ = http.NewRequest("GET", "/api/destinations/compare?ids=1,999", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	// -------------------------
+	// 9. Verify response fields are correct
+	// -------------------------
+	req, _ = http.NewRequest("GET", "/api/destinations/compare?ids=1,3", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	json.Unmarshal(w.Body.Bytes(), &res)
+	dests := res["destinations"].([]interface{})
+	paris := dests[0].(map[string]interface{})
+	bali := dests[1].(map[string]interface{})
+	assert.Equal(t, "France", paris["country"])
+	assert.Equal(t, float64(2000), paris["budget"])
+	assert.Equal(t, "Indonesia", bali["country"])
+	assert.Equal(t, float64(1500), bali["budget"])
+}

--- a/backend/models/compare.go
+++ b/backend/models/compare.go
@@ -1,0 +1,14 @@
+package models
+
+type DestinationComparison struct {
+	ID          int     `json:"id"`
+	Name        string  `json:"name"`
+	Country     string  `json:"country"`
+	Budget      float64 `json:"budget"`
+	Description string  `json:"description"`
+}
+
+type CompareResponse struct {
+	TotalDestinations int                     `json:"total_destinations"`
+	Destinations      []DestinationComparison `json:"destinations"`
+}

--- a/backend/router.go
+++ b/backend/router.go
@@ -85,6 +85,9 @@ func main() {
 		api.DELETE("/destinations/:id", handlers.DeleteDestination)
 		api.PUT("/destinations/:id", handlers.UpdateDestination)
 
+		// Compare destinations
+		api.GET("/destinations/compare", handlers.CompareDestinations)
+
 		// Review routes
 		api.POST("/destinations/:id/reviews", handlers.CreateReview)
 		api.GET("/destinations/:id/reviews", handlers.GetReviews)


### PR DESCRIPTION
Added destination comparison endpoint allowing users to compare 2-3 destinations side by side.

Changes:
- compare_handler.go: Single GET endpoint for comparing destinations
- compare_test.go: 9 unit tests covering all validation and success cases
- models/compare.go: CompareResponse and DestinationComparison models
- main.go: Compare route added to protected API group

Endpoints added:
- GET /api/destinations/compare?ids=1,2,3

Validations:
- Minimum 2 destinations required
- Maximum 3 destinations allowed
- Duplicate IDs rejected
- Invalid ID formats rejected
- Non-existent destinations return 404