### PR TITLE
Add travel and accommodation options feature for destinations with unit tests 

### DIFF
--- a/backend/handlers/teavel_test.go
+++ b/backend/handlers/teavel_test.go
@@ -1,0 +1,192 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"backend/database"
+	"backend/utils"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupTravelRouter() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+
+	r.Use(func(c *gin.Context) {
+		c.Set("user", &utils.Claims{UserID: 1})
+		c.Next()
+	})
+
+	r.GET("/api/destinations/:id/travel", GetTravelOptions)
+	r.GET("/api/destinations/:id/accommodations", GetAccommodationOptions)
+
+	return r
+}
+
+func setupTravelDB(t *testing.T) {
+	err := database.InitDB(":memory:")
+	if err != nil {
+		t.Fatalf("Failed to init test DB: %v", err)
+	}
+
+	_, err = database.DB.Exec(`
+		CREATE TABLE IF NOT EXISTS destinations (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT, country TEXT, budget REAL, description TEXT
+		);
+	`)
+	if err != nil {
+		t.Fatalf("Failed to create tables: %v", err)
+	}
+
+	// Seed destinations
+	database.DB.Exec(`INSERT INTO destinations (id, name, country, budget, description) VALUES (1, 'Paris', 'France', 2000, 'City of Light')`)
+	database.DB.Exec(`INSERT INTO destinations (id, name, country, budget, description) VALUES (2, 'Tokyo', 'Japan', 3000, 'Land of the Rising Sun')`)
+}
+
+func TestTravelFlow(t *testing.T) {
+	setupTravelDB(t)
+	defer database.CloseDB()
+
+	router := setupTravelRouter()
+
+	// -------------------------
+	// 1. Get Travel Options - Success
+	// -------------------------
+	req, _ := http.NewRequest("GET", "/api/destinations/1/travel", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var res map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &res)
+	assert.Equal(t, float64(1), res["destination_id"])
+	assert.Equal(t, "Paris", res["destination_name"])
+	assert.Equal(t, float64(4), res["total_options"])
+
+	// -------------------------
+	// 2. Verify Travel Options Content
+	// -------------------------
+	options := res["travel_options"].([]interface{})
+	assert.Equal(t, 4, len(options))
+
+	first := options[0].(map[string]interface{})
+	assert.Equal(t, "Flight", first["type"])
+	assert.NotEmpty(t, first["booking_link"])
+	assert.NotEmpty(t, first["estimated_cost"])
+
+	// -------------------------
+	// 3. Get Travel Options - Different Destination
+	// -------------------------
+	req, _ = http.NewRequest("GET", "/api/destinations/2/travel", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	json.Unmarshal(w.Body.Bytes(), &res)
+	assert.Equal(t, "Tokyo", res["destination_name"])
+
+	// -------------------------
+	// 4. Get Travel Options - Non-existent Destination
+	// -------------------------
+	req, _ = http.NewRequest("GET", "/api/destinations/999/travel", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	// -------------------------
+	// 5. Get Travel Options - Invalid ID
+	// -------------------------
+	req, _ = http.NewRequest("GET", "/api/destinations/abc/travel", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	// -------------------------
+	// 6. Get Accommodation Options - Success
+	// -------------------------
+	req, _ = http.NewRequest("GET", "/api/destinations/1/accommodations", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	json.Unmarshal(w.Body.Bytes(), &res)
+	assert.Equal(t, float64(1), res["destination_id"])
+	assert.Equal(t, "Paris", res["destination_name"])
+	assert.Equal(t, float64(4), res["total_options"])
+
+	// -------------------------
+	// 7. Verify Accommodation Options Content
+	// -------------------------
+	accommodations := res["accommodation_options"].([]interface{})
+	assert.Equal(t, 4, len(accommodations))
+
+	firstAccom := accommodations[0].(map[string]interface{})
+	assert.Equal(t, "Hotel", firstAccom["type"])
+	assert.NotEmpty(t, firstAccom["booking_link"])
+	assert.NotEmpty(t, firstAccom["estimated_cost"])
+
+	// -------------------------
+	// 8. Get Accommodation Options - Different Destination
+	// -------------------------
+	req, _ = http.NewRequest("GET", "/api/destinations/2/accommodations", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	json.Unmarshal(w.Body.Bytes(), &res)
+	assert.Equal(t, "Tokyo", res["destination_name"])
+
+	// -------------------------
+	// 9. Get Accommodation Options - Non-existent Destination
+	// -------------------------
+	req, _ = http.NewRequest("GET", "/api/destinations/999/accommodations", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	// -------------------------
+	// 10. Get Accommodation Options - Invalid ID
+	// -------------------------
+	req, _ = http.NewRequest("GET", "/api/destinations/abc/accommodations", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	// -------------------------
+	// 11. Verify Travel Options Have All Required Fields
+	// -------------------------
+	req, _ = http.NewRequest("GET", "/api/destinations/1/travel", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	json.Unmarshal(w.Body.Bytes(), &res)
+	travelOptions := res["travel_options"].([]interface{})
+	for _, opt := range travelOptions {
+		option := opt.(map[string]interface{})
+		assert.NotEmpty(t, option["name"])
+		assert.NotEmpty(t, option["type"])
+		assert.NotEmpty(t, option["estimated_cost"])
+		assert.NotEmpty(t, option["booking_link"])
+	}
+
+	// -------------------------
+	// 12. Verify Accommodation Options Have All Required Fields
+	// -------------------------
+	req, _ = http.NewRequest("GET", "/api/destinations/1/accommodations", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	json.Unmarshal(w.Body.Bytes(), &res)
+	accomOptions := res["accommodation_options"].([]interface{})
+	for _, opt := range accomOptions {
+		option := opt.(map[string]interface{})
+		assert.NotEmpty(t, option["name"])
+		assert.NotEmpty(t, option["type"])
+		assert.NotEmpty(t, option["estimated_cost"])
+		assert.NotEmpty(t, option["booking_link"])
+	}
+}

--- a/backend/handlers/travel_handler.go
+++ b/backend/handlers/travel_handler.go
@@ -1,0 +1,165 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"backend/database"
+	"backend/models"
+
+	"github.com/gin-gonic/gin"
+)
+
+// getSimulatedTravelOptions returns simulated travel options for a destination
+func getSimulatedTravelOptions(destinationName string) []models.TravelOption {
+	return []models.TravelOption{
+		{
+			ID:            1,
+			Type:          "Flight",
+			Name:          "Direct Flight to " + destinationName,
+			Description:   "Round trip direct flight with standard luggage included",
+			EstimatedCost: 450.00,
+			Currency:      "USD",
+			BookingLink:   "https://www.skyscanner.com",
+		},
+		{
+			ID:            2,
+			Type:          "Flight",
+			Name:          "Connecting Flight to " + destinationName,
+			Description:   "Round trip connecting flight, budget option",
+			EstimatedCost: 280.00,
+			Currency:      "USD",
+			BookingLink:   "https://www.kayak.com",
+		},
+		{
+			ID:            3,
+			Type:          "Train",
+			Name:          "Express Train to " + destinationName,
+			Description:   "High speed rail service, scenic route",
+			EstimatedCost: 120.00,
+			Currency:      "USD",
+			BookingLink:   "https://www.raileurope.com",
+		},
+		{
+			ID:            4,
+			Type:          "Bus",
+			Name:          "Coach Bus to " + destinationName,
+			Description:   "Comfortable coach service, most affordable option",
+			EstimatedCost: 45.00,
+			Currency:      "USD",
+			BookingLink:   "https://www.busbud.com",
+		},
+	}
+}
+
+// getSimulatedAccommodationOptions returns simulated accommodation options
+func getSimulatedAccommodationOptions(destinationName string) []models.AccommodationOption {
+	return []models.AccommodationOption{
+		{
+			ID:            1,
+			Name:          "Luxury Hotel " + destinationName,
+			Type:          "Hotel",
+			Description:   "5-star hotel with pool, spa, and breakfast included",
+			EstimatedCost: 350.00,
+			Currency:      "USD",
+			BookingLink:   "https://www.booking.com",
+		},
+		{
+			ID:            2,
+			Name:          "Boutique Hotel " + destinationName,
+			Type:          "Hotel",
+			Description:   "Charming 3-star boutique hotel in city center",
+			EstimatedCost: 150.00,
+			Currency:      "USD",
+			BookingLink:   "https://www.hotels.com",
+		},
+		{
+			ID:            3,
+			Name:          "Airbnb Apartment " + destinationName,
+			Type:          "Apartment",
+			Description:   "Entire apartment, great for families or groups",
+			EstimatedCost: 95.00,
+			Currency:      "USD",
+			BookingLink:   "https://www.airbnb.com",
+		},
+		{
+			ID:            4,
+			Name:          "Budget Hostel " + destinationName,
+			Type:          "Hostel",
+			Description:   "Clean and friendly hostel, shared or private rooms available",
+			EstimatedCost: 30.00,
+			Currency:      "USD",
+			BookingLink:   "https://www.hostelworld.com",
+		},
+	}
+}
+
+// GetTravelOptions returns simulated travel options for a destination
+func GetTravelOptions(c *gin.Context) {
+	destID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "bad_request",
+			Message: "Invalid destination ID",
+		})
+		return
+	}
+
+	// Check destination exists and get name
+	var destName string
+	err = database.DB.QueryRow(
+		"SELECT name FROM destinations WHERE id = ?", destID,
+	).Scan(&destName)
+
+	if err != nil {
+		c.JSON(http.StatusNotFound, models.ErrorResponse{
+			Error:   "not_found",
+			Message: "Destination not found",
+		})
+		return
+	}
+
+	options := getSimulatedTravelOptions(destName)
+
+	c.JSON(http.StatusOK, models.TravelResponse{
+		DestinationID:   destID,
+		DestinationName: destName,
+		TotalOptions:    len(options),
+		TravelOptions:   options,
+	})
+}
+
+// GetAccommodationOptions returns simulated accommodation options for a destination
+func GetAccommodationOptions(c *gin.Context) {
+	destID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "bad_request",
+			Message: "Invalid destination ID",
+		})
+		return
+	}
+
+	// Check destination exists and get name
+	var destName string
+	err = database.DB.QueryRow(
+		"SELECT name FROM destinations WHERE id = ?", destID,
+	).Scan(&destName)
+
+	if err != nil {
+		c.JSON(http.StatusNotFound, models.ErrorResponse{
+			Error:   "not_found",
+			Message: "Destination not found",
+		})
+		return
+	}
+
+	options := getSimulatedAccommodationOptions(destName)
+
+	c.JSON(http.StatusOK, models.AccommodationResponse{
+		DestinationID:        destID,
+		DestinationName:      destName,
+		TotalOptions:         len(options),
+		AccommodationOptions: options,
+	})
+}

--- a/backend/models/travel.go
+++ b/backend/models/travel.go
@@ -1,0 +1,35 @@
+package models
+
+type TravelOption struct {
+	ID          int     `json:"id"`
+	Type        string  `json:"type"`
+	Name        string  `json:"name"`
+	Description string  `json:"description"`
+	EstimatedCost float64 `json:"estimated_cost"`
+	Currency    string  `json:"currency"`
+	BookingLink string  `json:"booking_link"`
+}
+
+type AccommodationOption struct {
+	ID            int     `json:"id"`
+	Name          string  `json:"name"`
+	Type          string  `json:"type"`
+	Description   string  `json:"description"`
+	EstimatedCost float64 `json:"estimated_cost"`
+	Currency      string  `json:"currency"`
+	BookingLink   string  `json:"booking_link"`
+}
+
+type TravelResponse struct {
+	DestinationID   int            `json:"destination_id"`
+	DestinationName string         `json:"destination_name"`
+	TotalOptions    int            `json:"total_options"`
+	TravelOptions   []TravelOption `json:"travel_options"`
+}
+
+type AccommodationResponse struct {
+	DestinationID        int                   `json:"destination_id"`
+	DestinationName      string                `json:"destination_name"`
+	TotalOptions         int                   `json:"total_options"`
+	AccommodationOptions []AccommodationOption `json:"accommodation_options"`
+}

--- a/backend/router.go
+++ b/backend/router.go
@@ -109,6 +109,10 @@ func main() {
 		api.DELETE("/itineraries/:id/collaborators/:user_id", handlers.RemoveCollaborator)
 		api.DELETE("/itineraries/:id", handlers.DeleteItinerary)
 
+		// Travel and accommodation routes
+		api.GET("/destinations/:id/travel", handlers.GetTravelOptions)
+		api.GET("/destinations/:id/accommodations", handlers.GetAccommodationOptions)
+
 		// Budget routes
 		api.POST("/budgets", handlers.CreateBudget)
 		api.GET("/budgets", handlers.GetBudgets)


### PR DESCRIPTION
Added travel and accommodation options endpoints for destinations.

Changes:
- travel_handler.go: Two GET endpoints returning simulated travel 
  and accommodation options
- travel_test.go: 12 unit tests covering all endpoints
- models/travel.go: TravelOption, AccommodationOption and 
  response models
- main.go: Routes added to protected API group

Endpoints added:
- GET /api/destinations/:id/travel
- GET /api/destinations/:id/accommodations

Features:
- Returns 4 travel options per destination (flight, train, bus)
- Returns 4 accommodation options (hotel, boutique, airbnb, hostel)
- Each option includes name, type, estimated cost and booking link
- Destination name dynamically included in option names
- Returns 404 for non-existent destinations