### PR TITLE
Added analytics dashboard feature with unit tests

### DIFF
--- a/backend/handlers/analytics_handler.go
+++ b/backend/handlers/analytics_handler.go
@@ -1,0 +1,193 @@
+package handlers
+
+import (
+	"database/sql"
+	"net/http"
+
+	"backend/database"
+	"backend/models"
+	"backend/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+// GetAnalyticsSummary returns a summary of the user's trip and budget stats
+func GetAnalyticsSummary(c *gin.Context) {
+	userInterface, exists := c.Get("user")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, models.ErrorResponse{
+			Error:   "unauthorized",
+			Message: "User not authenticated",
+		})
+		return
+	}
+	claims := userInterface.(*utils.Claims)
+
+	// Get total trips
+	var totalTrips int
+	err := database.DB.QueryRow(
+		"SELECT COUNT(*) FROM trips WHERE user_id = ?", claims.UserID,
+	).Scan(&totalTrips)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+			Error:   "server_error",
+			Message: "Failed to fetch trip count",
+		})
+		return
+	}
+
+	// Get total budgets and total spent
+	var totalBudgets int
+	var totalSpent sql.NullFloat64
+	err = database.DB.QueryRow(
+		"SELECT COUNT(*), SUM(spent_amount) FROM budgets WHERE user_id = ?",
+		claims.UserID,
+	).Scan(&totalBudgets, &totalSpent)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+			Error:   "server_error",
+			Message: "Failed to fetch budget stats",
+		})
+		return
+	}
+
+	spent := 0.0
+	if totalSpent.Valid {
+		spent = totalSpent.Float64
+	}
+
+	avgSpent := 0.0
+	if totalTrips > 0 {
+		avgSpent = spent / float64(totalTrips)
+	}
+
+	c.JSON(http.StatusOK, models.AnalyticsSummaryResponse{
+		UserID: claims.UserID,
+		Summary: models.AnalyticsSummary{
+			TotalTrips:          totalTrips,
+			TotalSpent:          spent,
+			TotalBudgets:        totalBudgets,
+			AverageSpentPerTrip: avgSpent,
+		},
+	})
+}
+
+// GetAnalyticsTrips returns a list of the user's trips with cost details
+func GetAnalyticsTrips(c *gin.Context) {
+	userInterface, exists := c.Get("user")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, models.ErrorResponse{
+			Error:   "unauthorized",
+			Message: "User not authenticated",
+		})
+		return
+	}
+	claims := userInterface.(*utils.Claims)
+
+	rows, err := database.DB.Query(`
+		SELECT 
+			t.id, 
+			t.trip_name, 
+			COALESCE(t.destination, '') as destination,
+			COALESCE(date(t.start_date), '') as start_date,
+			COALESCE(date(t.end_date), '') as end_date,
+			t.status,
+			COALESCE(b.spent_amount, 0) as total_cost
+		FROM trips t
+		LEFT JOIN budgets b ON b.trip_id = t.id
+		WHERE t.user_id = ?
+		ORDER BY t.created_at DESC
+	`, claims.UserID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+			Error:   "server_error",
+			Message: "Failed to fetch trips",
+		})
+		return
+	}
+	defer rows.Close()
+
+	trips := []models.AnalyticsTrip{}
+	for rows.Next() {
+		var trip models.AnalyticsTrip
+		err := rows.Scan(
+			&trip.ID,
+			&trip.TripName,
+			&trip.Destination,
+			&trip.StartDate,
+			&trip.EndDate,
+			&trip.Status,
+			&trip.TotalCost,
+		)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+				Error:   "server_error",
+				Message: "Error reading trips",
+			})
+			return
+		}
+		trips = append(trips, trip)
+	}
+
+	c.JSON(http.StatusOK, models.AnalyticsTripsResponse{
+		UserID:     claims.UserID,
+		TotalTrips: len(trips),
+		Trips:      trips,
+	})
+}
+
+// GetAnalyticsExpenses returns expense breakdown by category for the user
+func GetAnalyticsExpenses(c *gin.Context) {
+	userInterface, exists := c.Get("user")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, models.ErrorResponse{
+			Error:   "unauthorized",
+			Message: "User not authenticated",
+		})
+		return
+	}
+	claims := userInterface.(*utils.Claims)
+
+	rows, err := database.DB.Query(`
+		SELECT 
+			e.category,
+			SUM(e.amount) as total_amount,
+			COUNT(*) as count
+		FROM expenses e
+		JOIN budgets b ON e.budget_id = b.id
+		WHERE b.user_id = ?
+		GROUP BY e.category
+		ORDER BY total_amount DESC
+	`, claims.UserID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+			Error:   "server_error",
+			Message: "Failed to fetch expense analytics",
+		})
+		return
+	}
+	defer rows.Close()
+
+	categories := []models.AnalyticsExpenseCategory{}
+	totalSpent := 0.0
+
+	for rows.Next() {
+		var cat models.AnalyticsExpenseCategory
+		err := rows.Scan(&cat.Category, &cat.TotalAmount, &cat.Count)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+				Error:   "server_error",
+				Message: "Error reading expense data",
+			})
+			return
+		}
+		totalSpent += cat.TotalAmount
+		categories = append(categories, cat)
+	}
+
+	c.JSON(http.StatusOK, models.AnalyticsExpensesResponse{
+		UserID:     claims.UserID,
+		TotalSpent: totalSpent,
+		Categories: categories,
+	})
+}

--- a/backend/handlers/analytics_test.go
+++ b/backend/handlers/analytics_test.go
@@ -1,0 +1,217 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"backend/database"
+	"backend/utils"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupAnalyticsRouter() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+
+	r.Use(func(c *gin.Context) {
+		c.Set("user", &utils.Claims{UserID: 1})
+		c.Next()
+	})
+
+	r.GET("/api/analytics/summary", GetAnalyticsSummary)
+	r.GET("/api/analytics/trips", GetAnalyticsTrips)
+	r.GET("/api/analytics/expenses", GetAnalyticsExpenses)
+
+	return r
+}
+
+func setupAnalyticsDB(t *testing.T) {
+	err := database.InitDB(":memory:")
+	if err != nil {
+		t.Fatalf("Failed to init test DB: %v", err)
+	}
+
+	_, err = database.DB.Exec(`
+		CREATE TABLE IF NOT EXISTS trips (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			user_id INTEGER NOT NULL,
+			trip_name TEXT NOT NULL,
+			destination TEXT,
+			start_date DATETIME,
+			end_date DATETIME,
+			status TEXT DEFAULT 'planning',
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		);
+		CREATE TABLE IF NOT EXISTS budgets (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			user_id INTEGER NOT NULL,
+			trip_id INTEGER,
+			trip_name TEXT NOT NULL,
+			total_budget REAL NOT NULL,
+			spent_amount REAL DEFAULT 0,
+			currency TEXT DEFAULT 'USD',
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		);
+		CREATE TABLE IF NOT EXISTS expenses (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			budget_id INTEGER NOT NULL,
+			category TEXT NOT NULL,
+			amount REAL NOT NULL,
+			description TEXT,
+			expense_date DATETIME DEFAULT CURRENT_TIMESTAMP,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		);
+	`)
+	if err != nil {
+		t.Fatalf("Failed to create tables: %v", err)
+	}
+
+	// Seed trips
+	database.DB.Exec(`INSERT INTO trips (id, user_id, trip_name, destination, status) VALUES (1, 1, 'Paris Trip', 'Paris', 'completed')`)
+	database.DB.Exec(`INSERT INTO trips (id, user_id, trip_name, destination, status) VALUES (2, 1, 'Tokyo Trip', 'Tokyo', 'planning')`)
+
+	// Seed budgets linked to trips
+	database.DB.Exec(`INSERT INTO budgets (id, user_id, trip_id, trip_name, total_budget, spent_amount) VALUES (1, 1, 1, 'Paris Budget', 3000, 1500)`)
+	database.DB.Exec(`INSERT INTO budgets (id, user_id, trip_id, trip_name, total_budget, spent_amount) VALUES (2, 1, 2, 'Tokyo Budget', 4000, 800)`)
+
+	// Seed expenses
+	database.DB.Exec(`INSERT INTO expenses (budget_id, category, amount, description) VALUES (1, 'Accommodation', 800, 'Hotel')`)
+	database.DB.Exec(`INSERT INTO expenses (budget_id, category, amount, description) VALUES (1, 'Food', 400, 'Restaurants')`)
+	database.DB.Exec(`INSERT INTO expenses (budget_id, category, amount, description) VALUES (1, 'Transport', 300, 'Metro')`)
+	database.DB.Exec(`INSERT INTO expenses (budget_id, category, amount, description) VALUES (2, 'Accommodation', 500, 'Airbnb')`)
+	database.DB.Exec(`INSERT INTO expenses (budget_id, category, amount, description) VALUES (2, 'Food', 300, 'Restaurants')`)
+}
+
+func TestAnalyticsFlow(t *testing.T) {
+	setupAnalyticsDB(t)
+	defer database.CloseDB()
+
+	router := setupAnalyticsRouter()
+
+	// -------------------------
+	// 1. Get Summary - Success
+	// -------------------------
+	req, _ := http.NewRequest("GET", "/api/analytics/summary", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var res map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &res)
+	assert.Equal(t, float64(1), res["user_id"])
+
+	summary := res["summary"].(map[string]interface{})
+	assert.Equal(t, float64(2), summary["total_trips"])
+	assert.Equal(t, float64(2), summary["total_budgets"])
+	assert.Equal(t, float64(2300), summary["total_spent"])
+	assert.Equal(t, float64(1150), summary["average_spent_per_trip"])
+
+	// -------------------------
+	// 2. Get Summary - Empty (user 2 has no data)
+	// -------------------------
+	// AFTER:
+	emptyRouter := gin.Default()
+	emptyRouter.Use(func(c *gin.Context) {
+		c.Set("user", &utils.Claims{UserID: 99})
+		c.Next()
+	})
+	emptyRouter.GET("/api/analytics/summary", GetAnalyticsSummary)
+	emptyRouter.GET("/api/analytics/trips", GetAnalyticsTrips)
+	emptyRouter.GET("/api/analytics/expenses", GetAnalyticsExpenses)
+
+	req, _ = http.NewRequest("GET", "/api/analytics/summary", nil)
+	w = httptest.NewRecorder()
+	emptyRouter.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	json.Unmarshal(w.Body.Bytes(), &res)
+	summary = res["summary"].(map[string]interface{})
+	assert.Equal(t, float64(0), summary["total_trips"])
+	assert.Equal(t, float64(0), summary["total_spent"])
+
+	// -------------------------
+	// 3. Get Trips - Success
+	// -------------------------
+	req, _ = http.NewRequest("GET", "/api/analytics/trips", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	json.Unmarshal(w.Body.Bytes(), &res)
+	assert.Equal(t, float64(2), res["total_trips"])
+
+	trips := res["trips"].([]interface{})
+	assert.Equal(t, 2, len(trips))
+
+	// -------------------------
+	// 4. Verify Trip Fields
+	// -------------------------
+	firstTrip := trips[0].(map[string]interface{})
+	assert.NotEmpty(t, firstTrip["trip_name"])
+	assert.NotEmpty(t, firstTrip["status"])
+	assert.NotEmpty(t, firstTrip["destination"])
+
+	// -------------------------
+	// 5. Get Trips - Empty for unknown user
+	// -------------------------
+	req, _ = http.NewRequest("GET", "/api/analytics/trips", nil)
+	w = httptest.NewRecorder()
+	emptyRouter.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	json.Unmarshal(w.Body.Bytes(), &res)
+	assert.Equal(t, float64(0), res["total_trips"])
+
+	// -------------------------
+	// 6. Get Expenses - Success
+	// -------------------------
+	req, _ = http.NewRequest("GET", "/api/analytics/expenses", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	json.Unmarshal(w.Body.Bytes(), &res)
+	assert.Equal(t, float64(1), res["user_id"])
+	assert.Equal(t, float64(2300), res["total_spent"])
+
+	// -------------------------
+	// 7. Verify Expense Categories
+	// -------------------------
+	categories := res["categories"].([]interface{})
+	assert.Equal(t, 3, len(categories))
+
+	firstCat := categories[0].(map[string]interface{})
+	assert.NotEmpty(t, firstCat["category"])
+	assert.NotEmpty(t, firstCat["total_amount"])
+	assert.NotEmpty(t, firstCat["count"])
+
+	// -------------------------
+	// 8. Verify Categories Ordered by Amount Descending
+	// -------------------------
+	firstAmount := categories[0].(map[string]interface{})["total_amount"].(float64)
+	secondAmount := categories[1].(map[string]interface{})["total_amount"].(float64)
+	assert.GreaterOrEqual(t, firstAmount, secondAmount)
+
+	// -------------------------
+	// 9. Verify Accommodation is Highest Category
+	// -------------------------
+	topCategory := categories[0].(map[string]interface{})["category"].(string)
+	assert.Equal(t, "Accommodation", topCategory)
+
+	// -------------------------
+	// 10. Get Expenses - Empty for unknown user
+	// -------------------------
+	req, _ = http.NewRequest("GET", "/api/analytics/expenses", nil)
+	w = httptest.NewRecorder()
+	emptyRouter.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	json.Unmarshal(w.Body.Bytes(), &res)
+	assert.Equal(t, float64(0), res["total_spent"])
+}

--- a/backend/models/analytics.go
+++ b/backend/models/analytics.go
@@ -1,0 +1,41 @@
+package models
+
+type AnalyticsSummary struct {
+	TotalTrips          int     `json:"total_trips"`
+	TotalSpent          float64 `json:"total_spent"`
+	TotalBudgets        int     `json:"total_budgets"`
+	AverageSpentPerTrip float64 `json:"average_spent_per_trip"`
+}
+
+type AnalyticsTrip struct {
+	ID          int     `json:"id"`
+	TripName    string  `json:"trip_name"`
+	Destination string  `json:"destination"`
+	StartDate   string  `json:"start_date,omitempty"`
+	EndDate     string  `json:"end_date,omitempty"`
+	Status      string  `json:"status"`
+	TotalCost   float64 `json:"total_cost"`
+}
+
+type AnalyticsExpenseCategory struct {
+	Category    string  `json:"category"`
+	TotalAmount float64 `json:"total_amount"`
+	Count       int     `json:"count"`
+}
+
+type AnalyticsSummaryResponse struct {
+	UserID  int              `json:"user_id"`
+	Summary AnalyticsSummary `json:"summary"`
+}
+
+type AnalyticsTripsResponse struct {
+	UserID     int             `json:"user_id"`
+	TotalTrips int             `json:"total_trips"`
+	Trips      []AnalyticsTrip `json:"trips"`
+}
+
+type AnalyticsExpensesResponse struct {
+	UserID     int                        `json:"user_id"`
+	TotalSpent float64                    `json:"total_spent"`
+	Categories []AnalyticsExpenseCategory `json:"categories"`
+}

--- a/backend/router.go
+++ b/backend/router.go
@@ -120,6 +120,11 @@ func main() {
 		api.PUT("/budgets/:id", handlers.UpdateBudget)
 		api.DELETE("/budgets/:id", handlers.DeleteBudget)
 
+		// Analytics routes
+		api.GET("/analytics/summary", handlers.GetAnalyticsSummary)
+		api.GET("/analytics/trips", handlers.GetAnalyticsTrips)
+		api.GET("/analytics/expenses", handlers.GetAnalyticsExpenses)
+
 		// Expense routes (under budget)
 		api.POST("/budgets/:id/expenses", handlers.AddExpense)
 		api.GET("/budgets/:id/expenses", handlers.GetExpenses)


### PR DESCRIPTION
Added analytics dashboard endpoints giving users insights 
into their trip statistics and spending habits.

Changes:
- analytics_handler.go: Three GET endpoints for summary,
  trips and expense analytics
- analytics_test.go: 10 unit tests covering all endpoints
- models/analytics.go: Analytics response models
- main.go: Analytics routes added to protected API group

Endpoints added:
- GET /api/analytics/summary
- GET /api/analytics/trips  
- GET /api/analytics/expenses

Features:
- Summary: total trips, total spent, total budgets,
  average spent per trip
- Trips: full list of user trips with destination,
  dates, status and total cost
- Expenses: breakdown by category ordered by amount
  descending, total spent across all budgets
- All endpoints return empty state gracefully
  when user has no data
- Uses existing trips, budgets and expenses tables,
  no new tables required